### PR TITLE
only call dirs if necessary and join as path

### DIFF
--- a/src/storage/database.rs
+++ b/src/storage/database.rs
@@ -8,14 +8,10 @@ pub struct DatabaseConnection;
 impl DatabaseConnection {
     pub fn establish_connection() -> SqliteConnection {
         dotenv().ok();
-        let db = format!(
-            "{}/do/org.devloop.Do.db",
-            dirs::data_dir().unwrap().display()
-        );
-        let database_url = match env::var("DATABASE_URL") {
-            Ok(url) => url,
-            Err(_) => db,
-        };
+
+        let database_url = env::var("DATABASE_URL")
+            .unwrap_or_else(|_| dirs::data_dir().unwrap().join("do/org.devloop.Do.db").display().to_string());
+
         SqliteConnection::establish(&database_url)
             .unwrap_or_else(|_| panic!("Error connecting to {}", database_url))
     }


### PR DESCRIPTION
the `dirs` variable is only used in one of the two branches of the match. This can better be expressed by `unwrap_or_else`. Also use the `.join()` function of the path instead of joining as strings.